### PR TITLE
Use valid category value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Jonathan Meyer <jon@stejsoftware.com>
 maintainer=Jonathan Meyer <jon@stejsoftware.com>
 sentence=A collection of objects and utilities for the Arduino.
 paragraph=A collection of objects and utilities for the Arduino.
-category=Utility
+category=Other
 url=https://github.com/stejsoftware/ArduinoLibrary
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:

WARNING: Category 'Utility' in library ArduinoLibrary is not valid. Setting to 'Uncategorized'

on every compilation.

See:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format